### PR TITLE
Added list of matches to exception thrown when a partial path matches more than one webjar asset

### DIFF
--- a/src/main/java/org/webjars/MultipleMatchesException.java
+++ b/src/main/java/org/webjars/MultipleMatchesException.java
@@ -1,12 +1,21 @@
 package org.webjars;
 
+import java.util.List;
+
 /**
  * Thrown when a path matches multiple assets.
  */
 public class MultipleMatchesException extends IllegalArgumentException {
 
-    public MultipleMatchesException(final String message) {
+    private final List<String> matches;
+
+    public MultipleMatchesException(final String message, List<String> matches) {
         super(message);
+        this.matches = matches;
+    }
+
+    public List<String> getMatches() {
+      return matches;
     }
 
 }

--- a/src/main/java/org/webjars/WebJarAssetLocator.java
+++ b/src/main/java/org/webjars/WebJarAssetLocator.java
@@ -4,12 +4,14 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ServiceLoader;
@@ -219,14 +221,28 @@ public class WebJarAssetLocator {
         }
         final String fullPath = fullPathEntry.getValue();
 
-        if (fullPathTailIter.hasNext()
-                && fullPathTailIter.next().getKey()
-                .startsWith(reversePartialPath)) {
-            throw new MultipleMatchesException(
-                    "Multiple matches found for "
-                            + partialPath
-                            + ". Please provide a more specific path, for example by including a version number."
-            );
+        if (fullPathTailIter.hasNext()) {
+            List<String> matches = null;
+
+            while (fullPathTailIter.hasNext()) {
+                Entry<String, String> next = fullPathTailIter.next();
+                if (next.getKey().startsWith(reversePartialPath)) {
+                    if (matches == null) {
+                        matches = new ArrayList<String>();
+                    }
+                    matches.add(next.getValue());
+                } else {
+                    break;
+                }
+            }
+
+            if (matches != null) {
+                matches.add(fullPath);
+                throw new MultipleMatchesException(
+                        "Multiple matches found for "
+                                + partialPath
+                                + ". Please provide a more specific path, for example by including a version number.", matches);
+            }
         }
 
         return fullPath;

--- a/src/test/java/org/webjars/WebJarAssetLocatorTest.java
+++ b/src/test/java/org/webjars/WebJarAssetLocatorTest.java
@@ -1,11 +1,14 @@
 package org.webjars;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -115,6 +118,16 @@ public class WebJarAssetLocatorTest {
             fail("Exception should have been thrown!");
         } catch (MultipleMatchesException e) {
             assertEquals("Multiple matches found for multiple.js. Please provide a more specific path, for example by including a version number.", e.getMessage());
+            assertThat(e.getMatches(), contains("META-INF/resources/webjars/multiple/2.0.0/multiple.js", "META-INF/resources/webjars/multiple/1.0.0/multiple.js"));
+        }
+    }
+    
+    @Test
+    public void should_throw_exceptions_when_all_assets_match() throws Exception {
+        try {
+            new WebJarAssetLocator(new HashSet<String>(Arrays.asList("a/multi.js", "b/multi.js"))).getFullPath("multi.js");
+        } catch (MultipleMatchesException e) {
+            assertThat(e.getMatches(), contains("b/multi.js", "a/multi.js"));
         }
     }
 


### PR DESCRIPTION
This allows the client to find out what the matches are and possibly resolve the conflict.