### PR TITLE
More exact filtering in filterPathIndexByPrefix()

### DIFF
--- a/src/main/java/org/webjars/WebJarAssetLocator.java
+++ b/src/main/java/org/webjars/WebJarAssetLocator.java
@@ -252,7 +252,7 @@ public class WebJarAssetLocator {
         SortedMap<String, String> filteredPathIndex = new TreeMap<String, String>();
         for (String key : pathIndex.keySet()) {
             String value = pathIndex.get(key);
-            if (value.startsWith(prefix)) {
+            if (value.startsWith(prefix) && value.charAt(prefix.length()) == '/') {
                 filteredPathIndex.put(key, value);
             }
         }


### PR DESCRIPTION
It is not enough to filter out WebJars with startsWith having similar names like angular and angular-router.