### PR TITLE
In some cases resources inside a path with spaces are not detected.

### DIFF
--- a/src/test/java/org/webjars/WebJarAssetLocatorTest.java
+++ b/src/test/java/org/webjars/WebJarAssetLocatorTest.java
@@ -120,8 +120,6 @@ public class WebJarAssetLocatorTest {
 
     private WebJarAssetLocator buildAssetLocatorWithPath(URL url)
             throws MalformedURLException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        System.out.println(url);
-        System.out.println(url.getPath());
         URLClassLoader classLoader = new URLClassLoader(new java.net.URL[]{url}, ClassLoader.getSystemClassLoader());
         return new WebJarAssetLocator(WebJarAssetLocator.getFullPathIndex(Pattern.compile(".*"), classLoader));
     }

--- a/src/test/java/org/webjars/WebJarAssetLocatorTest.java
+++ b/src/test/java/org/webjars/WebJarAssetLocatorTest.java
@@ -7,11 +7,16 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.net.URLClassLoader;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.junit.Test;
 
@@ -100,16 +105,25 @@ public class WebJarAssetLocatorTest {
 
     @Test
     public void should_work_with_classpath_containing_spaces() throws java.net.MalformedURLException, NoSuchMethodException, IllegalAccessException, java.lang.reflect.InvocationTargetException {
-        java.io.File f = new java.io.File("src/test/resources/space space");
-        java.net.URL u = f.toURL();
-        java.net.URLClassLoader urlClassLoader = (java.net.URLClassLoader) ClassLoader.getSystemClassLoader();
-        Class<URLClassLoader> urlClass = java.net.URLClassLoader.class;
-        java.lang.reflect.Method method = urlClass.getDeclaredMethod("addURL", new Class[]{java.net.URL.class});
-        method.setAccessible(true);
-        method.invoke(urlClassLoader, new Object[]{u});
-        WebJarAssetLocator locator = new WebJarAssetLocator();
+        WebJarAssetLocator locator = buildAssetLocatorWithPath(new File("src/test/resources/space space").toURL());
         String path = locator.getFullPath("spaces/2.0.0/spaces.js");
         assertEquals(path, "META-INF/resources/webjars/spaces/2.0.0/spaces.js");
+    }
+
+    @Test
+    public void should_work_with_classpath_containing_escaped_spaces() throws java.net.MalformedURLException, NoSuchMethodException, IllegalAccessException, java.lang.reflect.InvocationTargetException {
+        // this kind of escaped path is often created via URI.toUrl(), and should also work
+        WebJarAssetLocator locator = buildAssetLocatorWithPath(new File("src/test/resources/space space").toURI().toURL());
+        String path = locator.getFullPath("spaces/2.0.0/spaces.js");
+        assertEquals(path, "META-INF/resources/webjars/spaces/2.0.0/spaces.js");
+    }
+
+    private WebJarAssetLocator buildAssetLocatorWithPath(URL url)
+            throws MalformedURLException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        System.out.println(url);
+        System.out.println(url.getPath());
+        URLClassLoader classLoader = new URLClassLoader(new java.net.URL[]{url}, ClassLoader.getSystemClassLoader());
+        return new WebJarAssetLocator(WebJarAssetLocator.getFullPathIndex(Pattern.compile(".*"), classLoader));
     }
 
     @Test


### PR DESCRIPTION
When the path to a `META-INF/resources/webjars` folder is specified using a URL object obtained via `new File("some path").toUri().toUrl()` (which is the not-deprecated way of converting a File into a URL) then webjars-locator-core fails to locate the resources contained in that folder.

We currently have this problem in our st-js/st-js project, and this fix will help us to properly integrate webjars with ST-JS.