### PR TITLE
Use classLoaders when invoking ServiceLoader.load

### DIFF
--- a/src/main/java/org/webjars/WebJarAssetLocator.java
+++ b/src/main/java/org/webjars/WebJarAssetLocator.java
@@ -83,15 +83,20 @@ public class WebJarAssetLocator {
         final Set<String> assetPaths = new HashSet<String>();
         final Set<URL> urls = listParentURLsWithResource(classLoaders, WEBJARS_PATH_PREFIX);
 
-        ServiceLoader<UrlProtocolHandler> urlProtocolHandlers = ServiceLoader.load(UrlProtocolHandler.class);
+        List<ServiceLoader<UrlProtocolHandler>> serviceLoaders = new ArrayList<>();
+        for (ClassLoader cl : classLoaders) {
+            serviceLoaders.add(ServiceLoader.load(UrlProtocolHandler.class, cl));
+        }
 
         for (final URL url : urls) {
-            for (UrlProtocolHandler urlProtocolHandler : urlProtocolHandlers) {
-                if (urlProtocolHandler.accepts(url.getProtocol())) {
-                    Set<String> assetPathSet = urlProtocolHandler.getAssetPaths(url, filterExpr, classLoaders);
-                    if(assetPathSet != null) {
-                        assetPaths.addAll(assetPathSet);
-                        break;
+            for (ServiceLoader<UrlProtocolHandler> urlProtocolHandlers : serviceLoaders) {
+                for (UrlProtocolHandler urlProtocolHandler : urlProtocolHandlers) {
+                    if (urlProtocolHandler.accepts(url.getProtocol())) {
+                        Set<String> assetPathSet = urlProtocolHandler.getAssetPaths(url, filterExpr, classLoaders);
+                        if (assetPathSet != null) {
+                            assetPaths.addAll(assetPathSet);
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The root cause of issue ["getFullPath does not work in an sbt plugin"](https://github.com/webjars/webjars-locator/issues/96) is that the `classLoaders` passed to `getAssetPaths` were not forwarded to the call to `ServiceLoader.load()`.  When not passing a `classLoader`, [`ServiceLoader.load()` utilizes the current thread's context class loader](http://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html#load%28java.lang.Class%29). In the case of running an sbt plugin, this particular `classLoader` does not have a `UrlProtocolHandler` available.  

Utilizing the `classLoaders` resolves this issue.  
