### PR TITLE
Locate the UrlProtocolHandler service with WebJarAssetLocator's ClassLoader

### DIFF
--- a/src/main/java/org/webjars/WebJarAssetLocator.java
+++ b/src/main/java/org/webjars/WebJarAssetLocator.java
@@ -83,7 +83,7 @@ public class WebJarAssetLocator {
         final Set<String> assetPaths = new HashSet<String>();
         final Set<URL> urls = listParentURLsWithResource(classLoaders, WEBJARS_PATH_PREFIX);
 
-        ServiceLoader<UrlProtocolHandler> urlProtocolHandlers = ServiceLoader.load(UrlProtocolHandler.class);
+        ServiceLoader<UrlProtocolHandler> urlProtocolHandlers = ServiceLoader.load(UrlProtocolHandler.class, WebJarAssetLocator.class.getClassLoader());
 
         for (final URL url : urls) {
             for (UrlProtocolHandler urlProtocolHandler : urlProtocolHandlers) {


### PR DESCRIPTION
See PR #10 and [Issue 96](https://github.com/webjars/webjars-locator/issues/96) for discussion and details.