### PR TITLE
Remove redundant close method.

### DIFF
--- a/src/main/java/org/webjars/CloseQuietly.java
+++ b/src/main/java/org/webjars/CloseQuietly.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.jar.JarFile;
 
 /**
  * Utility for closing resources without throwing an exception (because you should never throw an exception from a
@@ -23,15 +22,4 @@ public class CloseQuietly {
             }
         }
     }
-
-    public static void closeQuietly(JarFile jarFile) {
-        if (jarFile != null) {
-            try {
-                jarFile.close();
-            } catch (IOException e) {
-                log.debug("Exception while closing resource", e);
-            }
-        }
-    }
-
 }


### PR DESCRIPTION
`JarFile` extends `ZipFile` that implements `Closeable` already, so it makes no sense to have both methods in the file.