### PR TITLE
Replace redundant generic type declarations with diamond operator.

### DIFF
--- a/src/main/java/org/webjars/FileSystemCache.java
+++ b/src/main/java/org/webjars/FileSystemCache.java
@@ -78,7 +78,7 @@ public class FileSystemCache implements WebJarExtractor.Cache {
             }
         }
         onFile = touched;
-        touched = new HashMap<String, Cacheable>();
+        touched = new HashMap<>();
         dirty = false;
     }
 
@@ -90,7 +90,7 @@ public class FileSystemCache implements WebJarExtractor.Cache {
      * @throws IOException If an error occurred.
      */
     public void reset() throws IOException {
-        onFile = new HashMap<String, Cacheable>();
+        onFile = new HashMap<>();
         if (cache.exists()) {
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(cache), StandardCharsets.UTF_8))) {
                 String line = reader.readLine();
@@ -113,7 +113,7 @@ public class FileSystemCache implements WebJarExtractor.Cache {
                 }
             }
         }
-        touched = new HashMap<String, Cacheable>();
+        touched = new HashMap<>();
         dirty = false;
     }
 

--- a/src/main/java/org/webjars/WebJarAssetLocator.java
+++ b/src/main/java/org/webjars/WebJarAssetLocator.java
@@ -46,7 +46,7 @@ public class WebJarAssetLocator {
      * Return all {@link URL}s defining {@value WebJarAssetLocator#WEBJARS_PATH_PREFIX} directory, either identifying JAR files or plain directories.
      */
     static Set<URL> listParentURLsWithResource(final ClassLoader[] classLoaders, final String resource) {
-        final Set<URL> urls = new HashSet<URL>();
+        final Set<URL> urls = new HashSet<>();
         for (final ClassLoader classLoader : classLoaders) {
             try {
                 final Enumeration<URL> enumeration = classLoader.getResources(resource);
@@ -66,7 +66,7 @@ public class WebJarAssetLocator {
      */
     private static Set<String> getAssetPaths(final Pattern filterExpr,
                                              final ClassLoader... classLoaders) {
-        final Set<String> assetPaths = new HashSet<String>();
+        final Set<String> assetPaths = new HashSet<>();
         final Set<URL> urls = listParentURLsWithResource(classLoaders, WEBJARS_PATH_PREFIX);
 
         ServiceLoader<UrlProtocolHandler> urlProtocolHandlers = ServiceLoader.load(UrlProtocolHandler.class);
@@ -106,7 +106,7 @@ public class WebJarAssetLocator {
 
         final Set<String> assetPaths = getAssetPaths(filterExpr, classLoaders);
 
-        final SortedMap<String, String> assetPathIndex = new TreeMap<String, String>();
+        final SortedMap<String, String> assetPathIndex = new TreeMap<>();
         for (final String assetPath : assetPaths) {
             assetPathIndex.put(reversePath(assetPath), assetPath);
         }
@@ -149,7 +149,7 @@ public class WebJarAssetLocator {
     }
 
     public WebJarAssetLocator(Set<String> assetPaths) {
-        this.fullPathIndex = new TreeMap<String, String>();
+        this.fullPathIndex = new TreeMap<>();
 
         for (String assetPath : assetPaths) {
             fullPathIndex.put(reversePath(assetPath), assetPath);
@@ -232,7 +232,7 @@ public class WebJarAssetLocator {
                 Entry<String, String> next = fullPathTailIter.next();
                 if (next.getKey().startsWith(reversePartialPath)) {
                     if (matches == null) {
-                        matches = new ArrayList<String>();
+                        matches = new ArrayList<>();
                     }
                     matches.add(next.getValue());
                 } else {
@@ -253,7 +253,7 @@ public class WebJarAssetLocator {
     }
 
     private SortedMap<String, String> filterPathIndexByPrefix(SortedMap<String, String> pathIndex, String prefix) {
-        SortedMap<String, String> filteredPathIndex = new TreeMap<String, String>();
+        SortedMap<String, String> filteredPathIndex = new TreeMap<>();
         for (String key : pathIndex.keySet()) {
             String value = pathIndex.get(key);
             if (value.startsWith(prefix)) {
@@ -279,7 +279,7 @@ public class WebJarAssetLocator {
      */
     public Set<String> listAssets(final String folderPath) {
         final Collection<String> allAssets = fullPathIndex.values();
-        final Set<String> assets = new TreeSet<String>(IGNORE_CASE_COMPARATOR);
+        final Set<String> assets = new TreeSet<>(IGNORE_CASE_COMPARATOR);
         final String prefix = WEBJARS_PATH_PREFIX + (!folderPath.startsWith("/") ? "/" : "") + folderPath;
         for (final String asset : allAssets) {
             if (asset.startsWith(folderPath) || asset.startsWith(prefix)) {
@@ -294,7 +294,7 @@ public class WebJarAssetLocator {
      */
     public Map<String, String> getWebJars() {
 
-        Map<String, String> webjars = new HashMap<String, String>();
+        Map<String, String> webjars = new HashMap<>();
 
         for (String webjarFile : fullPathIndex.values()) {
 
@@ -317,7 +317,7 @@ public class WebJarAssetLocator {
         if (matcher.find()) {
             String id = matcher.group(1);
             String version = matcher.group(2);
-            return new AbstractMap.SimpleEntry<String, String>(id, version);
+            return new AbstractMap.SimpleEntry<>(id, version);
         } else {
             // not a legal WebJar file format
             return null;

--- a/src/main/java/org/webjars/WebJarExtractor.java
+++ b/src/main/java/org/webjars/WebJarExtractor.java
@@ -240,7 +240,7 @@ public class WebJarExtractor {
     private class JarFileWebJar {
         final String name;
         final String version;
-        final Map<String, ZipArchiveEntry> entries = new HashMap<String, ZipArchiveEntry>();
+        final Map<String, ZipArchiveEntry> entries = new HashMap<>();
 
         String moduleId;
 
@@ -255,7 +255,7 @@ public class WebJarExtractor {
     }
 
     private Collection<JarFileWebJar> findWebJarsInJarFile(ZipFile zipFile, String moduleNameFile) throws IOException {
-        Map<String, JarFileWebJar> webJars = new HashMap<String, JarFileWebJar>();
+        Map<String, JarFileWebJar> webJars = new HashMap<>();
 
         // Loop through all the entries in the jar file, and extract every entry that is a webjar entry into a set
         // of WebJar name/versions to JarFileWebJars
@@ -379,7 +379,7 @@ public class WebJarExtractor {
      */
     public static class MemoryCache implements Cache {
 
-        private final Map<String, Cacheable> cache = new HashMap<String, Cacheable>();
+        private final Map<String, Cacheable> cache = new HashMap<>();
 
         public boolean isUpToDate(String key, Cacheable cacheable) {
             return cacheable.equals(cache.get(key));
@@ -466,7 +466,7 @@ public class WebJarExtractor {
     }
 
     private static Set<PosixFilePermission> toPerms(int mode) {
-        Set<PosixFilePermission> perms = new HashSet<PosixFilePermission>();
+        Set<PosixFilePermission> perms = new HashSet<>();
         if ((mode & 0400) > 0) {
             perms.add(PosixFilePermission.OWNER_READ);
         }

--- a/src/main/java/org/webjars/urlprotocols/FileUrlProtocolHandler.java
+++ b/src/main/java/org/webjars/urlprotocols/FileUrlProtocolHandler.java
@@ -22,7 +22,7 @@ public class FileUrlProtocolHandler implements UrlProtocolHandler {
 
     @Override
     public Set<String> getAssetPaths(URL url, Pattern filterExpr, ClassLoader... classLoaders) {
-        final Set<String> assetPaths = new HashSet<String>();
+        final Set<String> assetPaths = new HashSet<>();
         final File file;
         // url may contain escaped spaces (%20), but may also contain un-escaped spaces because the URL class allows that.
         // Examples:
@@ -50,7 +50,7 @@ public class FileUrlProtocolHandler implements UrlProtocolHandler {
      * Recursively search all directories for relative file paths matching `filterExpr`.
      */
     private static Set<String> listFiles(final File file, final Pattern filterExpr) {
-        final Set<String> aggregatedChildren = new HashSet<String>();
+        final Set<String> aggregatedChildren = new HashSet<>();
         aggregateChildren(file, file, aggregatedChildren, filterExpr, 0);
         return aggregatedChildren;
     }

--- a/src/main/java/org/webjars/urlprotocols/JarUrlProtocolHandler.java
+++ b/src/main/java/org/webjars/urlprotocols/JarUrlProtocolHandler.java
@@ -18,7 +18,7 @@ public class JarUrlProtocolHandler implements UrlProtocolHandler {
 
     @Override
     public Set<String> getAssetPaths(URL url, Pattern filterExpr, ClassLoader... classLoaders) {
-        HashSet<String> assetPaths = new HashSet<String>();
+        HashSet<String> assetPaths = new HashSet<>();
 
         try {
             final JarURLConnection jarUrlConnection = (JarURLConnection) url.openConnection();

--- a/src/test/java/org/webjars/ManualIndexTest.java
+++ b/src/test/java/org/webjars/ManualIndexTest.java
@@ -14,7 +14,7 @@ public class ManualIndexTest {
 
     @Test
     public void should_find_full_path() throws Exception {
-        WebJarAssetLocator locator = new WebJarAssetLocator(new HashSet<String>(asList("META-INF/resources/myapp/app.js", "assets/users/login.css")));
+        WebJarAssetLocator locator = new WebJarAssetLocator(new HashSet<>(asList("META-INF/resources/myapp/app.js", "assets/users/login.css")));
 
         assertEquals("META-INF/resources/myapp/app.js", locator.getFullPath("app.js"));
         assertEquals("META-INF/resources/myapp/app.js", locator.getFullPath("myapp/app.js"));
@@ -24,7 +24,7 @@ public class ManualIndexTest {
 
     @Test
     public void should_list_assets() throws Exception {
-        WebJarAssetLocator locator = new WebJarAssetLocator(new HashSet<String>(asList("META-INF/resources/myapp/app.js", "assets/users/login.css", "META-INF/resources/webjars/third_party/1.5.2/file.js")));
+        WebJarAssetLocator locator = new WebJarAssetLocator(new HashSet<>(asList("META-INF/resources/myapp/app.js", "assets/users/login.css", "META-INF/resources/webjars/third_party/1.5.2/file.js")));
 
         assertThat(locator.listAssets("META-INF"), contains("META-INF/resources/myapp/app.js", "META-INF/resources/webjars/third_party/1.5.2/file.js"));
         assertThat(locator.listAssets("assets"), contains("assets/users/login.css"));
@@ -34,7 +34,7 @@ public class ManualIndexTest {
 
     @Test
     public void should_find_webjars() throws Exception {
-        WebJarAssetLocator locator = new WebJarAssetLocator(new HashSet<String>(asList("META-INF/resources/myapp/app.js", "assets/users/login.css", "META-INF/resources/webjars/third_party/1.5.2/file.js")));
+        WebJarAssetLocator locator = new WebJarAssetLocator(new HashSet<>(asList("META-INF/resources/myapp/app.js", "assets/users/login.css", "META-INF/resources/webjars/third_party/1.5.2/file.js")));
 
         Map<String, String> webJars = locator.getWebJars();
 

--- a/src/test/java/org/webjars/WebJarAssetLocatorTest.java
+++ b/src/test/java/org/webjars/WebJarAssetLocatorTest.java
@@ -138,7 +138,7 @@ public class WebJarAssetLocatorTest {
     @Test
     public void should_throw_exceptions_when_all_assets_match() throws Exception {
         try {
-            new WebJarAssetLocator(new HashSet<String>(Arrays.asList("a/multi.js", "b/multi.js"))).getFullPath("multi.js");
+            new WebJarAssetLocator(new HashSet<>(Arrays.asList("a/multi.js", "b/multi.js"))).getFullPath("multi.js");
         } catch (MultipleMatchesException e) {
             assertThat(e.getMatches(), contains("b/multi.js", "a/multi.js"));
         }

--- a/src/test/java/org/webjars/WebJarExtractorTest.java
+++ b/src/test/java/org/webjars/WebJarExtractorTest.java
@@ -255,7 +255,7 @@ public class WebJarExtractorTest {
     }
 
     private void assertOnlyContains(String... paths) {
-        List<File> files = new ArrayList<File>();
+        List<File> files = new ArrayList<>();
         for (String path : paths) {
             File file = new File(tmpDir, path);
             assertFileExists(file);
@@ -297,7 +297,7 @@ public class WebJarExtractorTest {
     }
 
     private List<File> getAllFiles(File dir) {
-        List<File> results = new ArrayList<File>();
+        List<File> results = new ArrayList<>();
         for (File file : dir.listFiles()) {
             if (file.isDirectory()) {
                 results.addAll(getAllFiles(file));

--- a/src/test/java/org/webjars/WebJarExtractorTestUtils.java
+++ b/src/test/java/org/webjars/WebJarExtractorTestUtils.java
@@ -17,7 +17,7 @@ public class WebJarExtractorTestUtils {
         final Set<URL> urls = WebJarAssetLocator.listParentURLsWithResource(
                 new ClassLoader[]{WebJarExtractorTest.class.getClassLoader()},
                 WEBJARS_PATH_PREFIX);
-        List<URL> webjarUrls = new ArrayList<URL>();
+        List<URL> webjarUrls = new ArrayList<>();
         for (URL url : urls) {
             if (url.getProtocol().equals("jar")) {
                 String path = url.getPath();

--- a/src/test/java/org/webjars/WebJarFilePermissionsTest.java
+++ b/src/test/java/org/webjars/WebJarFilePermissionsTest.java
@@ -71,7 +71,7 @@ public class WebJarFilePermissionsTest {
 
     private void assertPermissions(String file, PosixFilePermission... exp) throws IOException {
         Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(new File(extractDir, "permissions-jar/bin/" + file).toPath());
-        Set<PosixFilePermission> expected = new HashSet<PosixFilePermission>(Arrays.asList(exp));
+        Set<PosixFilePermission> expected = new HashSet<>(Arrays.asList(exp));
         for (PosixFilePermission e: expected) {
             if (!permissions.contains(e)) {
                 fail("WebJar " + testName + " extraction test file " + file + " did not have expected permission " + e);

--- a/src/test/java/org/webjars/urlprotocols/JarUrlProtocolHandlerTest.java
+++ b/src/test/java/org/webjars/urlprotocols/JarUrlProtocolHandlerTest.java
@@ -154,7 +154,7 @@ public class JarUrlProtocolHandlerTest {
         fatJarWriter.close();
 
         JarFileArchive jarFileArchive = new JarFileArchive(fatJarFile);
-        List<Archive> archives = new ArrayList<Archive>();
+        List<Archive> archives = new ArrayList<>();
         archives.add(jarFileArchive);
         archives.addAll(jarFileArchive.getNestedArchives(new EntryFilter() {
             private final AsciiBytes LIB = new AsciiBytes("lib/");
@@ -163,7 +163,7 @@ public class JarUrlProtocolHandlerTest {
                 return !entry.isDirectory() && entry.getName().startsWith(LIB);
             }
         }));
-        List<URL> archiveUrls = new ArrayList<URL>();
+        List<URL> archiveUrls = new ArrayList<>();
         for (Archive archive : archives) {
             archiveUrls.add(archive.getUrl());
         }


### PR DESCRIPTION
Diamond operator allows to omit lots of boilerplate and improve readability of the code.

Java 7 compliant: https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.9