### PR TITLE
Use constant for charset.

### DIFF
--- a/src/main/java/org/webjars/FileSystemCache.java
+++ b/src/main/java/org/webjars/FileSystemCache.java
@@ -3,6 +3,7 @@ package org.webjars;
 import org.webjars.WebJarExtractor.Cacheable;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -69,7 +70,7 @@ public class FileSystemCache implements WebJarExtractor.Cache {
      */
     public void save() throws IOException {
         if (dirty || onFile.size() != touched.size()) {
-            try (Writer writer = new OutputStreamWriter(new FileOutputStream(cache), "UTF-8")) {
+            try (Writer writer = new OutputStreamWriter(new FileOutputStream(cache), StandardCharsets.UTF_8)) {
                 for (Map.Entry<String, Cacheable> item : touched.entrySet()) {
                     writer.write(item.getKey() + ":" + item.getValue().getLastModified() + ":" + item.getValue().getPath() + "\n");
                 }
@@ -91,7 +92,7 @@ public class FileSystemCache implements WebJarExtractor.Cache {
     public void reset() throws IOException {
         onFile = new HashMap<String, Cacheable>();
         if (cache.exists()) {
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(cache), "UTF-8"))) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(cache), StandardCharsets.UTF_8))) {
                 String line = reader.readLine();
                 while (line != null) {
                     if (!line.isEmpty()) {

--- a/src/main/java/org/webjars/WebJarExtractor.java
+++ b/src/main/java/org/webjars/WebJarExtractor.java
@@ -13,6 +13,7 @@ import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermission;
@@ -105,7 +106,7 @@ public class WebJarExtractor {
                 File file = new File(URI.create(urlPath.substring(0, urlPath.indexOf("!"))));
                 log.debug("Loading webjars from {}", file);
 
-                try (ZipFile zipFile = new ZipFile(file, "utf-8")) {
+                try (ZipFile zipFile = new ZipFile(file, StandardCharsets.UTF_8.name())) {
                     // Find all the webjars inside this webjar. This set contains paths to all webjars.
                     Collection<JarFileWebJar> webJars = findWebJarsInJarFile(zipFile);
 
@@ -446,7 +447,7 @@ public class WebJarExtractor {
 
     private static String copyAndClose(InputStream source) throws IOException {
         StringBuilder sb = new StringBuilder();
-        try (Reader is = new InputStreamReader(source, "UTF-8")) {
+        try (Reader is = new InputStreamReader(source, StandardCharsets.UTF_8)) {
             char[] buffer = new char[8192];
             int read = is.read(buffer, 0, buffer.length);
             sb.append(buffer, 0, read);

--- a/src/main/java/org/webjars/urlprotocols/FileUrlProtocolHandler.java
+++ b/src/main/java/org/webjars/urlprotocols/FileUrlProtocolHandler.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -32,7 +33,7 @@ public class FileUrlProtocolHandler implements UrlProtocolHandler {
         // and paths of resources within the classpath (/META-INF/resources/webjars/my project/) are provided by different sources,
         // url.getPath() can actually contain BOTH escaped spaces and un-escaped spaces at the same time.
         try {
-            String decodedPath = URLDecoder.decode(url.getPath(), "UTF-8");
+            String decodedPath = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8.name());
             file = new File(decodedPath);
 
         } catch (UnsupportedEncodingException e){

--- a/src/test/java/org/webjars/urlprotocols/JarUrlProtocolHandlerTest.java
+++ b/src/test/java/org/webjars/urlprotocols/JarUrlProtocolHandlerTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -72,7 +73,7 @@ public class JarUrlProtocolHandlerTest {
         try (ZipOutputStream zip = new ZipOutputStream(new FileOutputStream(jarFile))) {
             for (String jsLibPath : jsLibPaths) {
                 zip.putNextEntry(new ZipEntry(WebJarAssetLocator.WEBJARS_PATH_PREFIX + "/" + jsLibPath));
-                zip.write("var test = true;".getBytes("UTF-8"));
+                zip.write("var test = true;".getBytes(StandardCharsets.UTF_8));
                 zip.closeEntry();
             }
         } catch (IOException e) {


### PR DESCRIPTION
Stop using hardcoded string for charset names and use standard library constants for this.

Java 7 compliant: https://docs.oracle.com/javase/7/docs/api/java/nio/charset/StandardCharsets.html