### PR TITLE
Set scope:test for org.webjars.npm:angular__http dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
             <groupId>org.webjars.npm</groupId>
             <artifactId>angular__http</artifactId>
             <version>2.4.10</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Assuming this was just an oversight - not fixing this is bringing a dependency to org.webjars.npm:angular__http in all consumers of web jars.