### PR TITLE
[wip]: Build against Java 8 & 11 and update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
+---
 language: java
-dist: trusty
-jdk:
-  - openjdk7
+
+env:
+  - TRAVIS_JDK=8
+  - TRAVIS_JDK=11
+
+before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
+install: jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx32m -version
+
+script: mvn test
+
 cache:
   directories:
-  - $HOME/.m2
+    - "$HOME/.m2"
+    - "$HOME/.jabba/jdk"

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -41,29 +41,31 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <slf4j.version>1.7.29</slf4j.version>
+        <springboot.version>2.2.1.RELEASE</springboot.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.7</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
-            <version>4.8.44</version>
+            <version>4.8.53</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.8</version>
+            <version>2.10.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.26</version>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -93,7 +95,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.8.5</version>
+            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -177,19 +179,19 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-loader</artifactId>
-            <version>1.1.8.RELEASE</version>
+            <version>${springboot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-loader-tools</artifactId>
-            <version>1.1.8.RELEASE</version>
+            <version>${springboot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -201,13 +203,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot</artifactId>
-            <version>1.5.7.RELEASE</version>
+            <version>${springboot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
-            <version>1.5.7.RELEASE</version>
+            <version>${springboot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -229,10 +231,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/src/test/java/org/webjars/WebJarAssetLocatorTest.java
+++ b/src/test/java/org/webjars/WebJarAssetLocatorTest.java
@@ -5,7 +5,8 @@ import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.webresources.StandardRoot;
 import org.apache.catalina.webresources.WarResourceSet;
 import org.junit.Test;
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedWebappClassLoader;
+import org.hamcrest.CoreMatchers;
+import org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLoader;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,8 +17,8 @@ import java.net.URLClassLoader;
 import java.util.*;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.*;
 
@@ -44,10 +45,10 @@ public class WebJarAssetLocatorTest {
     public void should_list_assets() throws Exception {
         WebJarAssetLocator locator = new WebJarAssetLocator(withList(asList("META-INF/resources/myapp/app.js", "assets/users/login.css", "META-INF/resources/webjars/third_party/1.5.2/file.js")));
 
-        assertThat(locator.listAssets("META-INF"), containsInAnyOrder("META-INF/resources/myapp/app.js", "META-INF/resources/webjars/third_party/1.5.2/file.js"));
-        assertThat(locator.listAssets("assets"), contains("assets/users/login.css"));
-        assertThat(locator.listAssets("third_party"), contains("META-INF/resources/webjars/third_party/1.5.2/file.js"));
-        assertThat(locator.listAssets(), containsInAnyOrder("META-INF/resources/myapp/app.js", "assets/users/login.css", "META-INF/resources/webjars/third_party/1.5.2/file.js"));
+        assertThat(locator.listAssets("META-INF"), CoreMatchers.hasItems("META-INF/resources/myapp/app.js", "META-INF/resources/webjars/third_party/1.5.2/file.js"));
+        assertThat(locator.listAssets("assets"), hasItem("assets/users/login.css"));
+        assertThat(locator.listAssets("third_party"), hasItem("META-INF/resources/webjars/third_party/1.5.2/file.js"));
+        assertThat(locator.listAssets(), CoreMatchers.hasItems("META-INF/resources/myapp/app.js", "assets/users/login.css", "META-INF/resources/webjars/third_party/1.5.2/file.js"));
     }
 
     @Test
@@ -161,7 +162,7 @@ public class WebJarAssetLocatorTest {
             fail("Exception should have been thrown!");
         } catch (MultipleMatchesException e) {
             assertEquals("Multiple matches found for multiple.js. Please provide a more specific path, for example by including a version number.", e.getMessage());
-            assertThat(e.getMatches(), containsInAnyOrder("META-INF/resources/webjars/multiple/2.0.0/multiple.js", "META-INF/resources/webjars/multiple/1.0.0/multiple.js"));
+            assertThat(e.getMatches(), CoreMatchers.hasItems("META-INF/resources/webjars/multiple/2.0.0/multiple.js", "META-INF/resources/webjars/multiple/1.0.0/multiple.js"));
         }
     }
 
@@ -170,7 +171,7 @@ public class WebJarAssetLocatorTest {
         try {
             new WebJarAssetLocator(withList(Arrays.asList("a/multi.js", "b/multi.js"))).getFullPath("multi.js");
         } catch (MultipleMatchesException e) {
-            assertThat(e.getMatches(), containsInAnyOrder("b/multi.js", "a/multi.js"));
+            assertThat(e.getMatches(), CoreMatchers.hasItems("b/multi.js", "a/multi.js"));
         } catch (URISyntaxException e) {
             fail("should not fail");
         }
@@ -191,7 +192,7 @@ public class WebJarAssetLocatorTest {
         String fullPathPrefix = "META-INF/resources/webjars/multiple/1.0.0/";
         Set<String> assets = new WebJarAssetLocator().listAssets("/multiple/1.0.0");
 
-        assertThat(assets, hasItems(fullPathPrefix + "multiple.js", fullPathPrefix + "module/multiple_module.js"));
+        assertThat(assets, CoreMatchers.hasItems(fullPathPrefix + "multiple.js", fullPathPrefix + "module/multiple_module.js"));
     }
 
     @Test

--- a/src/test/java/org/webjars/WebJarExtractorTest.java
+++ b/src/test/java/org/webjars/WebJarExtractorTest.java
@@ -3,7 +3,7 @@ package org.webjars;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.*;
 import java.net.*;


### PR DESCRIPTION
~~@jamesward upgrading classgraph dependency, which has some fixes for Java 11, resolved the broken jobs in https://github.com/webjars/webjars-play/pull/91. I've tried with a local build.~~

My mistake. This is not true yet.