### PR TITLE
Upgrade classgraph to 4.8.69

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
-            <version>4.8.64</version>
+            <version>4.8.69</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
The old version breaks in a JVM with no JMX.

```
Caused by: java.lang.NoClassDefFoundError: Could not initialize class sun.management.ManagementFactoryHelper
	at java.lang.management.ManagementFactory.getRuntimeMXBean(ManagementFactory.java:350) ~[na:1.8.0_102-internal]
	at io.github.classgraph.ModulePathInfo.<init>(ModulePathInfo.java:131) ~[classgraph-4.8.64.jar!/:4.8.64]
	at nonapi.io.github.classgraph.scanspec.ScanSpec.<init>(ScanSpec.java:231) ~[classgraph-4.8.64.jar!/:4.8.64]
	at io.github.classgraph.ClassGraph.<init>(ClassGraph.java:67) ~[classgraph-4.8.64.jar!/:4.8.64]
	at org.webjars.WebJarAssetLocator.<init>(WebJarAssetLocator.java:150) ~[webjars-locator-core-0.44.jar!/:na]
...
```