### PR TITLE
fix: Make class WebJarInfo public

### DIFF
--- a/src/main/java/org/webjars/WebJarAssetLocator.java
+++ b/src/main/java/org/webjars/WebJarAssetLocator.java
@@ -40,7 +40,7 @@ public class WebJarAssetLocator {
 
     private static final Pattern WEBJAR_EXTRACTOR_PATTERN = Pattern.compile(WEBJARS_PATH_PREFIX + "/([^/]*)/([^/]*)/(.*)$");
 
-    static class WebJarInfo {
+    public static class WebJarInfo {
 
         final String version;
         final String groupId;


### PR DESCRIPTION
Hi

The is public method to get jar details:
  ```java
       public Map<String, WebJarInfo> getAllWebJars()
  ```

But the class WebJarInfo wasn't public itself leading to an exception when trying to call getAllWebJars.