### PR TITLE
add license file to jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,17 @@
     </dependencies>
 
     <build>
+
+        <resources>
+            <resource>
+                <directory>.</directory>
+                <targetPath>META-INF</targetPath>
+                <includes>
+                    <include>LICENSE.md</include>
+                </includes>
+            </resource>
+        </resources>
+
         <plugins>
 
             <plugin>


### PR DESCRIPTION
For a customer project an OpenSource report has to be generated. Therefore a scanner was created to extract the licence information from our dependencies. This scanner can extract all informaton from the Jar file. Therefore it would be great to have the license information included in the Jar file as LICENSE.md file.