### PR TITLE
URGENT FIX: path separator in JAR file is always `/`, even on Windows

### DIFF
--- a/src/main/java/org/webjars/WebJarExtractor.java
+++ b/src/main/java/org/webjars/WebJarExtractor.java
@@ -40,6 +40,8 @@ public class WebJarExtractor {
     /** The bower.json file name. */
     public static final String BOWER_JSON = "bower.json";
 
+    private static final String JAR_PATH_DELIMITER = "/";
+
     private static final Logger log = LoggerFactory.getLogger(WebJarExtractor.class);
 
     private final ClassLoader classLoader;
@@ -130,7 +132,7 @@ public class WebJarExtractor {
     }
 
     private static void extractResource(@Nonnull String webJarName, @Nonnull WebJarInfo webJarInfo, @Nullable File to, @Nonnull String webJarId, @Nonnull Resource resource, @Nonnull InputStream inputStream) {
-        final String prefix = String.format("%s%s%s%s%s", WEBJARS_PATH_PREFIX, File.separator, webJarName, File.separator, webJarInfo.getVersion() == null ? "" : String.format("%s%s", webJarInfo.getVersion(), File.separator));
+        final String prefix = String.format("%s%s%s%s%s", WEBJARS_PATH_PREFIX, JAR_PATH_DELIMITER, webJarName, JAR_PATH_DELIMITER, webJarInfo.getVersion() == null ? "" : String.format("%s%s", webJarInfo.getVersion(), JAR_PATH_DELIMITER));
         if (resource.getPath().startsWith(prefix)) {
             final String newPath = resource.getPath().substring(prefix.length());
             final String relativeName = String.format("%s%s%s", webJarId, File.separator, newPath);


### PR DESCRIPTION
It is not platform-dependent (see https://stackoverflow.com/a/24749976/810109)

We run into that in the latest Play 2.9 release candidate. We have two reports where devs running Windows are not able to extract webjars, because right now the condition:
```java
if (resource.getPath().startsWith(prefix)) {
```
will always be false, because in Windows `\` is used instead of `/`, for example:
```
prefix: META-INF/resources/webjars\bootstrap\5.3.2\
resource.getPath(): META-INF/resources/webjars/bootstrap/5.3.2/scss/bootstrap.scss
```
You switched to `File.separator` in #28, not sure why you did that, but it just seems wrong.
In #42 the unused var `JAR_PATH_DELIMITER` finally got removed...

I tested this on a Windows machine and can confirm that before the fix running `webJars` with Play 2.9.0-RC3 does _not_ extract the webjars, with this fix however it does.

Would be fantastic if you could release 0.54 like... immediately :wink: Thanks!