### PR TITLE
Revert "Bump com.fasterxml.jackson.core:jackson-core from 2.15.2 to 2.16.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.16.1</version>
+            <version>2.15.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Reverts webjars/webjars-locator-core#135

Whoops. I think this causes incompat with Play.