### PR TITLE
If WebJar version is a "-snapshot", overwrite existing files when extracting

### DIFF
--- a/src/main/java/org/webjars/WebJarExtractor.java
+++ b/src/main/java/org/webjars/WebJarExtractor.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Map;
@@ -138,10 +139,11 @@ public class WebJarExtractor {
             final String newPath = resource.getPath().substring(prefix.length());
             final String relativeName = String.format("%s%s%s", webJarId, File.separator, newPath);
             final File newFile = new File(to, relativeName);
-            if (!newFile.exists()) {
+            final boolean allowOverwrite = webJarInfo.getVersion() != null && webJarInfo.getVersion().toLowerCase().endsWith("-snapshot");
+            if (!newFile.exists() || allowOverwrite) {
                 try {
                     newFile.getParentFile().mkdirs();
-                    Files.copy(inputStream, newFile.toPath());
+                    Files.copy(inputStream, newFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
                     inputStream.close();
                     Set<PosixFilePermission> resourcePerms = resource.getPosixFilePermissions();
                     if (resourcePerms != null && Files.getFileStore(newFile.toPath()).supportsFileAttributeView(PosixFileAttributeView.class)) {

--- a/src/test/java/org/webjars/WebJarAssetLocatorTest.java
+++ b/src/test/java/org/webjars/WebJarAssetLocatorTest.java
@@ -248,12 +248,13 @@ public class WebJarAssetLocatorTest {
     public void should_get_a_list_of_webjars() {
         Map<String, String> webjars = new WebJarAssetLocator().getWebJars();
 
-        assertThat(webjars.size(), is(38)); // this is the pom.xml ones plus the test resources (spaces, foo, bar-node, multiple)
+        assertThat(webjars.size(), is(39)); // this is the pom.xml ones plus the test resources (spaces, foo, bar-node, multiple)
         assertThat(webjars.get("bootstrap"), is("3.1.1"));
         assertThat(webjars.get("less-node"), is("1.6.0"));
         assertThat(webjars.get("jquery"), is("2.1.0"));
         assertThat(webjars.get("angularjs"), is("1.2.11"));
         assertThat(webjars.get("virtual-keyboard"), is("1.30.1"));
+        assertThat(webjars.get("wip"), is("1.0.0-SNAPSHOT"));
     }
 
     @Test

--- a/src/test/java/org/webjars/WebJarExtractorTest.java
+++ b/src/test/java/org/webjars/WebJarExtractorTest.java
@@ -64,6 +64,16 @@ public class WebJarExtractorTest {
     }
 
     @Test
+    public void extractWebJarShouldExtractWhenFileExistsAndWebJarVersionIsSnapshot() throws Exception {
+        WebJarExtractor extractor = new WebJarExtractor(createClassLoader());
+        File cacheDir = createTmpDir();
+        File file = new File(cacheDir, "wip/caramba.js");
+        createFile(file, "Hello");
+        extractor.extractWebJarTo("wip", cacheDir);
+        assertFileContains(file, "var just = 'do it';");
+    }
+
+    @Test
     public void extractAllWebJarsShouldExtractWhenFileDoesntExist() throws Exception {
         WebJarExtractor extractor = new WebJarExtractor(createClassLoader());
         extractor.extractAllWebJarsTo(createTmpDir());

--- a/src/test/resources/META-INF/resources/webjars/wip/1.0.0-SNAPSHOT/caramba.js
+++ b/src/test/resources/META-INF/resources/webjars/wip/1.0.0-SNAPSHOT/caramba.js
@@ -1,0 +1,1 @@
+var just = 'do it';


### PR DESCRIPTION
In general, Snapshots usually indicate things are still wip and changing (e.g., that's why you can overwrite artifacts in the [sonatype snapshot repository](https://s01.oss.sonatype.org/content/repositories/snapshots/)); therefore, existing files should get overwritten when extracting a webjar which obviously is a -snapshot release.

This change alone makes total sense on its own and will not break things, IMHO.

However, the real reason we need this behavior is because it helps us (Play) to fix:
- https://github.com/playframework/playframework/issues/12484
- https://github.com/orgs/playframework/discussions/12636

While developing a Play application and editing assets (css, js, etc.) in a sub-project, the sub-project's version usually is a -snapshot, so when a user edits an asset and refreshes the browser, the updated asset (which is internally a webjar) should be served. Currently, this is broken because files will not get overwritten. (I did test this locally with Play apps, and it works with this PR.)

@jamesward If you give thumbs up for this PR, would be nice if you could cut a new release also, thanks!